### PR TITLE
Remove warning about deps being expanded to deps()

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Queue.Mixfile do
      elixir: "~> 1.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   def application do


### PR DESCRIPTION
Hej @zambal,

thanks for the great work on the `Queue` module, its much nicer on your branch.
I took the liberty to fix the warning in `mix.exs`.

Enjoy and have a great day.